### PR TITLE
Support boolean values

### DIFF
--- a/src/Support/PhpParser/EnvCallNodeVisitor.php
+++ b/src/Support/PhpParser/EnvCallNodeVisitor.php
@@ -102,11 +102,15 @@ final class EnvCallNodeVisitor extends NodeVisitorAbstract
             return $this->print($providedDefault);
         }
 
-        if (! ($providedDefault instanceof Node\Scalar || $providedDefault instanceof Node\Expr\ConstFetch)) {
-            return null;
+        if ($providedDefault instanceof Node\Scalar) {
+            return $this->print($providedDefault);
         }
 
-        return $this->print($providedDefault);
+        if ($this->isBoolean($providedDefault)) {
+            return $this->print($providedDefault);
+        }
+
+        return null;
     }
 
     private function getComment(Node\Expr\FuncCall $node): string|null
@@ -135,5 +139,16 @@ final class EnvCallNodeVisitor extends NodeVisitorAbstract
         }
 
         return $this->printer->prettyPrint([$node]);
+    }
+
+    private function isBoolean(Node\Expr $providedDefault): bool
+    {
+        if (! $providedDefault instanceof Node\Expr\ConstFetch) {
+            return false;
+        }
+
+        $value = $providedDefault->name->parts[0];
+
+        return $value === 'true' || $value === 'false';
     }
 }

--- a/src/Support/PhpParser/EnvCallNodeVisitor.php
+++ b/src/Support/PhpParser/EnvCallNodeVisitor.php
@@ -102,7 +102,7 @@ final class EnvCallNodeVisitor extends NodeVisitorAbstract
             return $this->print($providedDefault);
         }
 
-        if (! $providedDefault instanceof Node\Scalar) {
+        if (! ($providedDefault instanceof Node\Scalar || $providedDefault instanceof Node\Expr\ConstFetch)) {
             return null;
         }
 

--- a/tests/Unit/Actions/FindEnvironmentCallsTest.php
+++ b/tests/Unit/Actions/FindEnvironmentCallsTest.php
@@ -76,6 +76,13 @@ it('correctly handles static ternary checks used as defaults', function () {
     expect($appEnv->getDefault())->toBeNull();
 });
 
+it('correctly handles boolean values used as defaults', function () {
+    $action = new FindEnvironmentCalls(defaultPhpParser());
+    $appEnv = $action(__DIR__ . '/../../Application/config/app.php')->get(7);
+
+    expect($appEnv->getDefault())->toEqual('false');
+});
+
 it('returns an empty collection if the parser returns null', function () {
     $parser = new class implements Parser {
         public function parse(string $code, ErrorHandler $errorHandler = null)


### PR DESCRIPTION
While trying out this package I noticed that boolean default values were not showing up in the `.env.example` file. Turns out that for whatever reason, the parser returns a node of `Node\Expr\ConstFetch` when the value is a `boolean`.

If you feel that this check is now too permissive, I was thinking that I could check if the value of the `ConstFetch` was a boolean as well.

Thanks for your consideration!