### PR TITLE
Adds support for Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,30 @@ This array is a collection of environment keys that we should never prune from y
 
 If you select the `Add to inclusions` option when running `php artisan envy:prune`, this array will be updated with the environment variables listed by that command.
 
+## Advanced
+
+Once you're familiar with the basics of Envy, you may find these advanced features useful.
+
+### Filters
+
+Sometimes, you'll want a more powerful way to represent items in the `exclusions` and `inclusion` lists than basic strings. For example, imagine you want to add all environment variables beginning with `STRIPE_` to the 
+exclusions list. Rather than manually inserting them all individually, you can use the `Worksome\Envy\Support\Filters\Filter` class.
+
+```php
+/**
+ * Any environment variables that are added to exclusions will never be inserted
+ * into .env files. Our defaults are based on the base Laravel config files.
+ * Feel free to add or remove variables as required by your project needs.
+ */
+'exclusions' => [
+    Filter::wildcard('STRIPE_*'),
+],
+```
+
+Now, any environment variable starting with `STRIPE_` will automatically be excluded when syncing to your configured environment files. We also offer `Filter::regex`, which is an even more powerful 
+filter that allows you to match environment variables against regular expression you provide. In fact, the `exclusions` and `inclusions` lists will accept a `string` or *any* class which implements
+the `Worksome\Envy\Contracts\Filter` contract, so you can even implement your own filters if that's your style.
+
 ## Testing
 
 Envy prides itself on a thorough test suite written in Pest, strict static analysis, and a very high level of code coverage. You may run these tests yourself by cloning the project and running our test script:

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Once you're familiar with the basics of Envy, you may find these advanced featur
 
 ### Filters
 
-Sometimes, you'll want a more powerful way to represent items in the `exclusions` and `inclusion` lists than basic strings. For example, imagine you want to add all environment variables beginning with `STRIPE_` to the 
+Sometimes, you'll want a more powerful way to represent items in the `exclusions` and `inclusions` lists than basic strings. For example, imagine you want to add all environment variables beginning with `STRIPE_` to the 
 exclusions list. Rather than manually inserting them all individually, you can use the `Worksome\Envy\Support\Filters\Filter` class.
 
 ```php

--- a/src/Actions/FilterEnvironmentCalls.php
+++ b/src/Actions/FilterEnvironmentCalls.php
@@ -37,7 +37,7 @@ final class FilterEnvironmentCalls implements FiltersEnvironmentCalls
     private function exclusionsContainVariable(string $environmentVariable): bool
     {
         return collect(($this->parseFilterList)($this->exclusions))
-            ->filter(fn(Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
+            ->filter(fn (Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
             ->isNotEmpty();
     }
 }

--- a/src/Actions/FilterEnvironmentCalls.php
+++ b/src/Actions/FilterEnvironmentCalls.php
@@ -37,7 +37,7 @@ final class FilterEnvironmentCalls implements FiltersEnvironmentCalls
     private function exclusionsContainVariable(string $environmentVariable): bool
     {
         return collect(($this->parseFilterList)($this->exclusions))
-            ->filter(fn (Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
+            ->filter(fn (Filter $filter) => $filter->check($environmentVariable))
             ->isNotEmpty();
     }
 }

--- a/src/Actions/FilterEnvironmentCalls.php
+++ b/src/Actions/FilterEnvironmentCalls.php
@@ -6,28 +6,38 @@ namespace Worksome\Envy\Actions;
 
 use Illuminate\Support\Collection;
 use Worksome\Envy\Contracts\Actions\FiltersEnvironmentCalls;
+use Worksome\Envy\Contracts\Actions\ParsesFilterList;
 use Worksome\Envy\Contracts\Actions\ReadsEnvironmentFile;
+use Worksome\Envy\Contracts\Filter;
 use Worksome\Envy\Support\EnvironmentCall;
 use Worksome\Envy\Support\EnvironmentVariable;
 
 final class FilterEnvironmentCalls implements FiltersEnvironmentCalls
 {
     /**
-     * @param array<int, string> $exclusions
+     * @param array<int, string|Filter> $exclusions
      */
     public function __construct(
         private ReadsEnvironmentFile $readEnvironmentFile,
+        private ParsesFilterList $parseFilterList,
         private array $exclusions = [],
     ) {
     }
 
     public function __invoke(string $filePath, Collection $environmentCalls): Collection
     {
-        $existingKeys = ($this->readEnvironmentFile)($filePath)->map(fn (EnvironmentVariable $variable) => $variable->getKey());
+        $existingKeys = ($this->readEnvironmentFile)($filePath)->map(fn(EnvironmentVariable $variable) => $variable->getKey());
 
         return $environmentCalls
-            ->unique(fn (EnvironmentCall $call) => $call->getKey())
-            ->reject(fn (EnvironmentCall $call) => $existingKeys->contains($call->getKey()))
-            ->reject(fn (EnvironmentCall $call) => in_array($call->getKey(), $this->exclusions));
+            ->unique(fn(EnvironmentCall $call) => $call->getKey())
+            ->reject(fn(EnvironmentCall $call) => $existingKeys->contains($call->getKey()))
+            ->reject(fn(EnvironmentCall $call) => $this->exclusionsContainVariable($call->getKey()));
+    }
+
+    private function exclusionsContainVariable(string $environmentVariable): bool
+    {
+        return collect(($this->parseFilterList)($this->exclusions))
+            ->filter(fn(Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
+            ->isNotEmpty();
     }
 }

--- a/src/Actions/FindEnvironmentVariablesToPrune.php
+++ b/src/Actions/FindEnvironmentVariablesToPrune.php
@@ -48,7 +48,7 @@ final class FindEnvironmentVariablesToPrune implements FindsEnvironmentVariables
     private function inclusionsContainVariable(string $environmentVariable): bool
     {
         return collect(($this->parsesFilterList)($this->inclusions))
-            ->filter(fn (Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
+            ->filter(fn (Filter $filter) => $filter->check($environmentVariable))
             ->isNotEmpty();
     }
 }

--- a/src/Actions/FindEnvironmentVariablesToPrune.php
+++ b/src/Actions/FindEnvironmentVariablesToPrune.php
@@ -6,17 +6,22 @@ namespace Worksome\Envy\Actions;
 
 use Illuminate\Support\Collection;
 use Worksome\Envy\Contracts\Actions\FindsEnvironmentVariablesToPrune;
+use Worksome\Envy\Contracts\Actions\ParsesFilterList;
 use Worksome\Envy\Contracts\Actions\ReadsEnvironmentFile;
+use Worksome\Envy\Contracts\Filter;
 use Worksome\Envy\Support\EnvironmentCall;
 use Worksome\Envy\Support\EnvironmentVariable;
 
 final class FindEnvironmentVariablesToPrune implements FindsEnvironmentVariablesToPrune
 {
     /**
-     * @param array<int, string> $inclusions
+     * @param array<int, string|Filter> $inclusions
      */
-    public function __construct(private ReadsEnvironmentFile $readEnvironmentFile, private array $inclusions = [])
-    {
+    public function __construct(
+        private ReadsEnvironmentFile $readEnvironmentFile,
+        private ParsesFilterList $parsesFilterList,
+        private array $inclusions = [],
+    ) {
     }
 
     public function __invoke(string $filePath, Collection $environmentCalls): Collection
@@ -25,7 +30,7 @@ final class FindEnvironmentVariablesToPrune implements FindsEnvironmentVariables
 
         return $this->environmentVariables($filePath)
             ->diff($variablesInEnvironmentCalls)
-            ->diff($this->inclusions)
+            ->reject(fn (string $variable) => $this->inclusionsContainVariable($variable))
             ->unique()
             ->sort()
             ->values();
@@ -38,5 +43,12 @@ final class FindEnvironmentVariablesToPrune implements FindsEnvironmentVariables
     {
         return ($this->readEnvironmentFile)($filePath)
             ->map(fn(EnvironmentVariable $environmentVariable) => $environmentVariable->getKey());
+    }
+
+    private function inclusionsContainVariable(string $environmentVariable): bool
+    {
+        return collect(($this->parsesFilterList)($this->inclusions))
+            ->filter(fn (Filter $filter) => $filter->environmentVariableMatches($environmentVariable))
+            ->isNotEmpty();
     }
 }

--- a/src/Actions/ParseFilterList.php
+++ b/src/Actions/ParseFilterList.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Actions;
+
+use Worksome\Envy\Contracts\Actions\ParsesFilterList;
+use Worksome\Envy\Contracts\Filter;
+use Worksome\Envy\Support\Filters\EqualityFilter;
+
+final class ParseFilterList implements ParsesFilterList
+{
+    public function __invoke(array $list): array
+    {
+        return array_map(fn (string|Filter $filter) => $this->transformFilter($filter), $list);
+    }
+
+    private function transformFilter(string|Filter $filter): Filter
+    {
+        if ($filter instanceof Filter) {
+            return $filter;
+        }
+
+        return new EqualityFilter($filter);
+    }
+}

--- a/src/Contracts/Actions/ParsesFilterList.php
+++ b/src/Contracts/Actions/ParsesFilterList.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Contracts\Actions;
+
+use Worksome\Envy\Contracts\Filter;
+
+interface ParsesFilterList
+{
+    /**
+     * @param array<int, string|Filter> $list
+     * @return array<int, Filter>
+     */
+    public function __invoke(array $list): array;
+}

--- a/src/Contracts/Filter.php
+++ b/src/Contracts/Filter.php
@@ -6,5 +6,5 @@ namespace Worksome\Envy\Contracts;
 
 interface Filter
 {
-    public function environmentVariableMatches(string $environmentVariable): bool;
+    public function check(string $environmentVariable): bool;
 }

--- a/src/Contracts/Filter.php
+++ b/src/Contracts/Filter.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Contracts;
+
+interface Filter
+{
+    public function environmentVariableMatches(string $environmentVariable): bool;
+}

--- a/src/EnvyServiceProvider.php
+++ b/src/EnvyServiceProvider.php
@@ -12,6 +12,7 @@ use Worksome\Envy\Actions\FilterEnvironmentCalls;
 use Worksome\Envy\Actions\FindEnvironmentCalls;
 use Worksome\Envy\Actions\FindEnvironmentVariablesToPrune;
 use Worksome\Envy\Actions\FormatEnvironmentCall;
+use Worksome\Envy\Actions\ParseFilterList;
 use Worksome\Envy\Actions\PruneEnvironmentFile;
 use Worksome\Envy\Actions\ReadEnvironmentFile;
 use Worksome\Envy\Actions\AddEnvironmentVariablesToList;
@@ -23,6 +24,7 @@ use Worksome\Envy\Contracts\Actions\FiltersEnvironmentCalls;
 use Worksome\Envy\Contracts\Actions\FindsEnvironmentCalls;
 use Worksome\Envy\Contracts\Actions\FindsEnvironmentVariablesToPrune;
 use Worksome\Envy\Contracts\Actions\FormatsEnvironmentCall;
+use Worksome\Envy\Contracts\Actions\ParsesFilterList;
 use Worksome\Envy\Contracts\Actions\PrunesEnvironmentFile;
 use Worksome\Envy\Contracts\Actions\ReadsEnvironmentFile;
 use Worksome\Envy\Contracts\Actions\AddsEnvironmentVariablesToList;
@@ -43,6 +45,7 @@ final class EnvyServiceProvider extends PackageServiceProvider
             'parser' => (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
         ]));
         $this->app->bind(ReadsEnvironmentFile::class, ReadEnvironmentFile::class);
+        $this->app->bind(ParsesFilterList::class, ParseFilterList::class);
         $this->app->bind(FiltersEnvironmentCalls::class, fn (Application $app) => $app->make(FilterEnvironmentCalls::class, [
             'exclusions' => $this->config()['exclusions'] ?? []
         ]));

--- a/src/Support/Filters/EqualityFilter.php
+++ b/src/Support/Filters/EqualityFilter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Support\Filters;
+
+use Worksome\Envy\Contracts\Filter;
+
+final class EqualityFilter implements Filter
+{
+    public function __construct(private string $comparison)
+    {
+    }
+
+    public function environmentVariableMatches(string $environmentVariable): bool
+    {
+        return $this->comparison === $environmentVariable;
+    }
+}

--- a/src/Support/Filters/EqualityFilter.php
+++ b/src/Support/Filters/EqualityFilter.php
@@ -12,7 +12,7 @@ final class EqualityFilter implements Filter
     {
     }
 
-    public function environmentVariableMatches(string $environmentVariable): bool
+    public function check(string $environmentVariable): bool
     {
         return $this->comparison === $environmentVariable;
     }

--- a/src/Support/Filters/Filter.php
+++ b/src/Support/Filters/Filter.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Support\Filters;
+
+use Illuminate\Support\Traits\Macroable;
+
+final class Filter
+{
+    use Macroable;
+
+    /**
+     * Create a new Wildcard filter. You may pass a different wildcard
+     * filter to the default '*' if required in order to avoid issues
+     * where your environment variable already contains a '*'.
+     *
+     * @param non-empty-string $wildcard
+     */
+    public static function wildcard(string $variable, string $wildcard = '*'): WildcardFilter
+    {
+        return new WildcardFilter($variable, $wildcard);
+    }
+
+    /**
+     * Create a new Regex filter. This filter accepts a regular expression
+     * that can be used to create more complex expectation for filtering
+     * environment variables when syncing and pruning.
+     */
+    public static function regex(string $pattern): RegexFilter
+    {
+        return new RegexFilter($pattern);
+    }
+}

--- a/src/Support/Filters/RegexFilter.php
+++ b/src/Support/Filters/RegexFilter.php
@@ -12,7 +12,7 @@ final class RegexFilter implements Filter
     {
     }
 
-    public function environmentVariableMatches(string $environmentVariable): bool
+    public function check(string $environmentVariable): bool
     {
         return preg_match($this->pattern, $environmentVariable) === 1;
     }

--- a/src/Support/Filters/RegexFilter.php
+++ b/src/Support/Filters/RegexFilter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Support\Filters;
+
+use Worksome\Envy\Contracts\Filter;
+
+final class RegexFilter implements Filter
+{
+    public function __construct(private string $pattern)
+    {
+    }
+
+    public function environmentVariableMatches(string $environmentVariable): bool
+    {
+        return preg_match($this->pattern, $environmentVariable) === 1;
+    }
+}

--- a/src/Support/Filters/WildcardFilter.php
+++ b/src/Support/Filters/WildcardFilter.php
@@ -15,7 +15,7 @@ final class WildcardFilter implements Filter
     {
     }
 
-    public function environmentVariableMatches(string $environmentVariable): bool
+    public function check(string $environmentVariable): bool
     {
         $comparison = collect(explode($this->wildcard, $this->comparison))
             ->map(fn (string $part) => preg_quote($part))

--- a/src/Support/Filters/WildcardFilter.php
+++ b/src/Support/Filters/WildcardFilter.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Worksome\Envy\Support\Filters;
+
+use Worksome\Envy\Contracts\Filter;
+
+final class WildcardFilter implements Filter
+{
+    /**
+     * @param non-empty-string $wildcard
+     */
+    public function __construct(private string $comparison, private string $wildcard)
+    {
+    }
+
+    public function environmentVariableMatches(string $environmentVariable): bool
+    {
+        $comparison = collect(explode($this->wildcard, $this->comparison))
+            ->map(fn (string $part) => preg_quote($part))
+            ->join('\S+');
+
+        return preg_match("/{$comparison}/", $environmentVariable) === 1;
+    }
+}

--- a/tests/Unit/Actions/FilterEnvironmentCallsTest.php
+++ b/tests/Unit/Actions/FilterEnvironmentCallsTest.php
@@ -54,7 +54,7 @@ it('can parse Filters in exclusions', function (bool $variableMatches, int $expe
         {
         }
 
-        public function environmentVariableMatches(string $environmentVariable): bool
+        public function check(string $environmentVariable): bool
         {
             return $this->variableMatches;
         }

--- a/tests/Unit/Actions/FilterEnvironmentCallsTest.php
+++ b/tests/Unit/Actions/FilterEnvironmentCallsTest.php
@@ -48,8 +48,8 @@ it('removes keys from the given exclusions', function () {
     expect($action(testAppPath('.env.example'), $calls))->toHaveCount(0);
 });
 
-it('can parse Describers in exclusions', function (bool $variableMatches, int $expectedFilteredCallCount) {
-    $customDescriber = new class ($variableMatches) implements Filter {
+it('can parse Filters in exclusions', function (bool $variableMatches, int $expectedFilteredCallCount) {
+    $customFilter = new class ($variableMatches) implements Filter {
         public function __construct(private bool $variableMatches)
         {
         }
@@ -69,7 +69,7 @@ it('can parse Describers in exclusions', function (bool $variableMatches, int $e
     $action = new FilterEnvironmentCalls(
         new ReadEnvironmentFile(),
         new ParseFilterList(),
-        [$customDescriber],
+        [$customFilter],
     );
 
     expect($action(testAppPath('.env.example'), $calls))->toHaveCount($expectedFilteredCallCount);

--- a/tests/Unit/Actions/FindEnvironmentVariablesToPruneTest.php
+++ b/tests/Unit/Actions/FindEnvironmentVariablesToPruneTest.php
@@ -1,11 +1,13 @@
 <?php
 
 use Worksome\Envy\Actions\FindEnvironmentVariablesToPrune;
+use Worksome\Envy\Actions\ParseFilterList;
 use Worksome\Envy\Actions\ReadEnvironmentFile;
 use Worksome\Envy\Support\EnvironmentCall;
+use Worksome\Envy\Support\Filters\Filter;
 
 it('returns the diff of the environment file and the given environment calls', function () {
-    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile());
+    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile(), new ParseFilterList());
     $variables = $action(testAppPath('.env.example'), collect([
         new EnvironmentCall(testAppPath('config/app.php'), 1, 'APP_NAME'),
         new EnvironmentCall(testAppPath('config/app.php'), 1, 'APP_TITLE'),
@@ -21,7 +23,7 @@ it('returns the diff of the environment file and the given environment calls', f
 });
 
 it('removes duplicates', function () {
-    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile());
+    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile(), new ParseFilterList());
     $variables = $action(testAppPath('environments/.env.with-duplicates'), collect())->all();
 
     expect($variables)->toBe([
@@ -30,8 +32,21 @@ it('removes duplicates', function () {
 });
 
 it('will not include variables on the given inclusions', function () {
-    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile(), [
-        'APP_NAME',
+    $action = new FindEnvironmentVariablesToPrune(
+        new ReadEnvironmentFile(),
+        new ParseFilterList(),
+        ['APP_NAME', 'APP_TITLE']
+    );
+    $variables = $action(testAppPath('.env.example'), collect())->all();
+
+    expect($variables)
+        ->not->toContain('APP_NAME')
+        ->not->toContain('APP_TITLE');
+});
+
+it('will can parse Filters in inclusions', function () {
+    $action = new FindEnvironmentVariablesToPrune(new ReadEnvironmentFile(), new ParseFilterList(), [
+        Filter::wildcard('APP_*', '*'),
         'APP_TITLE'
     ]);
     $variables = $action(testAppPath('.env.example'), collect())->all();

--- a/tests/Unit/Actions/ParseFilterListTest.php
+++ b/tests/Unit/Actions/ParseFilterListTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Worksome\Envy\Actions\ParseFilterList;
+use Worksome\Envy\Support\Filters\EqualityFilter;
+
+it('transforms strings to EqualityFilters', function () {
+    $parseFilterList = new ParseFilterList();
+
+    $result = $parseFilterList([
+        'FOO',
+        'BAR',
+        'BAZ',
+        new EqualityFilter('BOOM'),
+    ]);
+
+    expect($result)
+        ->toHaveCount(4)
+        ->each->toBeInstanceOf(EqualityFilter::class);
+});

--- a/tests/Unit/Support/Filters/EqualityFilterTest.php
+++ b/tests/Unit/Support/Filters/EqualityFilterTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\Envy\Support\Filters\EqualityFilter;
+
+it('succeeds if the given value is identical', function (mixed $value, mixed $comparison, bool $result) {
+    $filter = new EqualityFilter($comparison);
+
+    expect($filter->environmentVariableMatches($value))->toBe($result);
+})->with([
+    ['foo', 'foo', true],
+    ['foo', 'bar', false],
+]);

--- a/tests/Unit/Support/Filters/EqualityFilterTest.php
+++ b/tests/Unit/Support/Filters/EqualityFilterTest.php
@@ -7,7 +7,7 @@ use Worksome\Envy\Support\Filters\EqualityFilter;
 it('succeeds if the given value is identical', function (mixed $value, mixed $comparison, bool $result) {
     $filter = new EqualityFilter($comparison);
 
-    expect($filter->environmentVariableMatches($value))->toBe($result);
+    expect($filter->check($value))->toBe($result);
 })->with([
     ['foo', 'foo', true],
     ['foo', 'bar', false],

--- a/tests/Unit/Support/Filters/FilterTest.php
+++ b/tests/Unit/Support/Filters/FilterTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Worksome\Envy\Support\Filters\Filter;
+use Worksome\Envy\Support\Filters\RegexFilter;
+use Worksome\Envy\Support\Filters\WildcardFilter;
+
+it('can create a wildcard filter', function () {
+    expect(Filter::wildcard('FOO_*'))->toBeInstanceOf(WildcardFilter::class);
+});
+
+it('can create a regex filter', function () {
+    expect(Filter::regex('/\w+_\w+/'))->toBeInstanceOf(RegexFilter::class);
+});

--- a/tests/Unit/Support/Filters/RegexFilterTest.php
+++ b/tests/Unit/Support/Filters/RegexFilterTest.php
@@ -7,7 +7,7 @@ use Worksome\Envy\Support\Filters\RegexFilter;
 it('matches based on the given regular expression', function (string $regex, string $comparison, bool $matches) {
     $filter = new RegexFilter($regex);
 
-    expect($filter->environmentVariableMatches($comparison))->toBe($matches);
+    expect($filter->check($comparison))->toBe($matches);
 })->with([
     ['/\w+/', 'blahblahblah', true],
     ['/\w/', ' ', false],

--- a/tests/Unit/Support/Filters/RegexFilterTest.php
+++ b/tests/Unit/Support/Filters/RegexFilterTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\Envy\Support\Filters\RegexFilter;
+
+it('matches based on the given regular expression', function (string $regex, string $comparison, bool $matches) {
+    $filter = new RegexFilter($regex);
+
+    expect($filter->environmentVariableMatches($comparison))->toBe($matches);
+})->with([
+    ['/\w+/', 'blahblahblah', true],
+    ['/\w/', ' ', false],
+    ['/\s/', 'FOO_BAR', false],
+    ['/\w+_\w+_\w+/', 'FOO_BAR_BAZ', true],
+]);

--- a/tests/Unit/Support/Filters/WildcardFilterTest.php
+++ b/tests/Unit/Support/Filters/WildcardFilterTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Worksome\Envy\Support\Filters\WildcardFilter;
+
+it('matches based on the given wildcard character', function (string $variable, string $comparison, bool $matches) {
+    $filter = new WildcardFilter($variable, '%');
+
+    expect($filter->environmentVariableMatches($comparison))->toBe($matches);
+})->with([
+    ['FOO_%', 'FOO_BAR', true],
+    ['FOO_%', 'FOO_BAZ', true],
+    ['FOO_%', 'FOO_', false],
+    ['FOO_%', 'BAZ_FOO', false],
+    ['FOO_%', 'BAZ', false],
+    ['FOO%BAR', 'FOO_BAR', true],
+    ['%BAR', 'FOOBAR', true],
+]);

--- a/tests/Unit/Support/Filters/WildcardFilterTest.php
+++ b/tests/Unit/Support/Filters/WildcardFilterTest.php
@@ -7,9 +7,10 @@ use Worksome\Envy\Support\Filters\WildcardFilter;
 it('matches based on the given wildcard character', function (string $variable, string $comparison, bool $matches) {
     $filter = new WildcardFilter($variable, '%');
 
-    expect($filter->environmentVariableMatches($comparison))->toBe($matches);
+    expect($filter->check($comparison))->toBe($matches);
 })->with([
     ['FOO_%', 'FOO_BAR', true],
+    ['FOO_%', 'FOO_BAR_BAR', true],
     ['FOO_%', 'FOO_BAZ', true],
     ['FOO_%', 'FOO_', false],
     ['FOO_%', 'BAZ_FOO', false],


### PR DESCRIPTION
This PR is an implementation for #4 

As suggested, we have a new contract: `Worksome\Envy\Contracts\Filter`, which allows implementations to define different ways of checking if an environment variable should be excluded or included. All strings in the `inclusions` and `exclusions` arrays are automatically wrapped in the `Worksome\Envy\Support\Filters\EqualityFilter`, which does a standard `===` check.

There are two additional filters included in this PR: `Filter::wildcard` and `Filter::regex`. They are both quite self explanatory. Here is an example of usage:

```php
/**
 * Any environment variables that are added to exclusions will never be inserted
 * into .env files. Our defaults are based on the base Laravel config files.
 * Feel free to add or remove variables as required by your project needs.
 */
'exclusions' => [
    Filter::wildcard('STRIPE_*'),
    'FOO_BAR',
    'BOO_FAR*', // Note that because this will resolve to an EqualityFilter, no wildcard match will be used on the '*'
    Filter::wildcard('LARAVEL_%', '%'), // The wildcard filter accepts a 2nd parameter for defining a different wildcard character
    Filter::regex('/\w+_WEBHOOK_URL/'),
],
```