### PR TITLE
Check .env.example's presence, create one if needed

### DIFF
--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Worksome\Envy\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
 use Worksome\Envy\Commands\Concerns\HasUsefulConsoleMethods;
 
 final class InstallCommand extends Command
@@ -18,6 +20,17 @@ final class InstallCommand extends Command
     public function handle(): int
     {
         $this->call('vendor:publish', ['--tag' => 'envy-config']);
+
+        if (!File::exists('.env.example')) {
+            if (
+                $this->confirm('Do you want to create a .env.example file? This file will be used to store your configuration data.')
+            ) {
+                $envExample =  Http::get('https://raw.githubusercontent.com/laravel/laravel/9.x/.env.example')->body();
+                File::put('.env.example', $envExample);
+            } else {
+                $this->warn('You will need to create a .env.example file to store your configuration data.');
+            }
+        }
 
         $this->information('Alright, Envy is ready to rock! Get started with either `php artisan envy:sync` or `php artisan envy:prune`.');
 


### PR DESCRIPTION
So in the install command script, we will:
1. check if .env.example is presence in the folder
2. ask user, and create it if yes, else warn them to make one later.
@lukeraymonddowning this will hopefully close this issue #8 