### PR TITLE
Set Laravel illuminate/contracts >= 8.80

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.0|^8.1",
-        "illuminate/contracts": "^8.73 || ^9.0",
+        "illuminate/contracts": "^8.80 || ^9.0",
         "nikic/php-parser": "^4.13",
         "nunomaduro/termwind": "^1.4",
         "spatie/laravel-package-tools": "^1.9.2",


### PR DESCRIPTION
`Blade::render` method used in `SyncCommand` is not available for Laravel < 8.80. 