### PR TITLE
Add AWS_BUCKET to default values

### DIFF
--- a/config/envy.php
+++ b/config/envy.php
@@ -88,9 +88,10 @@ return [
         'REDIS_CACHE_DB',
         'MYSQL_ATTR_SSL_CA',
 
-        // config/filesystem.php
+        // config/filesystems.php
         'AWS_ENDPOINT',
         'AWS_URL',
+        'AWS_BUCKET',
 
         // config/hashing.php
         'BCRYPT_ROUNDS',


### PR DESCRIPTION
The value for AWS_BUCKET was not in the default values to ignore.
https://github.com/laravel/laravel/blob/9.x/config/filesystems.php#L52