### PR TITLE
Update Termwind Layouts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.0|^8.1",
         "illuminate/contracts": "^8.80 || ^9.0",
         "nikic/php-parser": "^4.13",
-        "nunomaduro/termwind": "^1.4",
+        "nunomaduro/termwind": "^1.10",
         "spatie/laravel-package-tools": "^1.9.2",
         "thecodingmachine/safe": "^2.1"
     },

--- a/src/Commands/Concerns/HasUsefulConsoleMethods.php
+++ b/src/Commands/Concerns/HasUsefulConsoleMethods.php
@@ -41,10 +41,10 @@ trait HasUsefulConsoleMethods
     }
 
     private function askUserToStarRepository(): void
-    {
+    {<span>
         render('
             <footer class="mx-2 my-1 italic">
-                ⭐️ <a href="https://github.com/worksome/envy">If you like Exchange, show your support by starring the repository!</a> ⭐️
+                ⭐️ <a href="https://github.com/worksome/envy">If you like Envy, show your support by starring the repository!</a> ⭐️
             </footer>
         ');
     }

--- a/src/Commands/Concerns/HasUsefulConsoleMethods.php
+++ b/src/Commands/Concerns/HasUsefulConsoleMethods.php
@@ -41,7 +41,7 @@ trait HasUsefulConsoleMethods
     }
 
     private function askUserToStarRepository(): void
-    {<span>
+    {
         render('
             <footer class="mx-2 my-1 italic">
                 ⭐️ <a href="https://github.com/worksome/envy">If you like Envy, show your support by starring the repository!</a> ⭐️

--- a/src/Commands/Concerns/HasUsefulConsoleMethods.php
+++ b/src/Commands/Concerns/HasUsefulConsoleMethods.php
@@ -16,7 +16,7 @@ trait HasUsefulConsoleMethods
     private function success(string $message): self
     {
         render("
-        <div class='my-1 px-1 py-1 bg-green-500 font-bold'>$message</div>
+        <div class='mx-2 px-2 py-1 bg-green-500 font-bold'>$message</div>
         ");
 
         return $this;
@@ -25,7 +25,7 @@ trait HasUsefulConsoleMethods
     private function warning(string $message): self
     {
         render("
-        <div class='px-1 py-1 bg-yellow-500 text-black font-bold'>$message</div>
+        <div class='mx-2 px-2 py-1 bg-yellow-500 text-black font-bold'>$message</div>
         ");
 
         return $this;
@@ -34,7 +34,7 @@ trait HasUsefulConsoleMethods
     private function information(string $message): self
     {
         render("
-        <div class='px-1 py-1 bg-blue-500 text-black font-bold text-gray-50'>$message</div>
+        <div class='mx-2 my-1 px-2 py-1 bg-blue-500 text-black font-bold text-gray-50'>$message</div>
         ");
 
         return $this;
@@ -43,9 +43,9 @@ trait HasUsefulConsoleMethods
     private function askUserToStarRepository(): void
     {
         render('
-            <a href="https://github.com/worksome/envy" class="my-1 px-1 py-1 bg-blue-500 font-bold w-full text-center">
-                ⭐️ If you like Envy, show your support by starring the repository! ⭐️
-            </a>
+            <footer class="mx-2 my-1 italic">
+                ⭐️ <a href="https://github.com/worksome/envy">If you like Exchange, show your support by starring the repository!</a> ⭐️
+            </footer>
         ');
     }
 }

--- a/src/Commands/PruneCommand.php
+++ b/src/Commands/PruneCommand.php
@@ -40,7 +40,7 @@ final class PruneCommand extends Command
         }
 
         if ($pendingPrunes->isEmpty()) {
-            render('<div class="px-1 py-1 bg-green-500 font-bold">There are no variables to prune!</div>');
+            render('<div class="mx-2 my-1 py-1 px-2 bg-green-500 font-bold">There are no variables to prune!</div>');
             return self::SUCCESS;
         }
 
@@ -78,27 +78,27 @@ final class PruneCommand extends Command
      */
     private function printPendingPrunes(Collection $pendingPrunes): void
     {
-        render(Blade::render('
-        <div>
-        @foreach($pendingPrunes as $path => $environmentVariables)
-        <div class="my-1">
-            <div class="px-2 py-1 w-full bg-green-500 font-bold">
-                <span class="text-left w-1/2">
-                    {{ $environmentVariables->count() }} {{ Str::plural("variable", $environmentVariables->count()) }} to remove for {{ Str::after($path, base_path()) }}
-                </span>
-                <span class="text-right w-1/2">
-                    {{ $loop->iteration }}/{{ $loop->count }}
-                </span>
-            </div>
-            <ul class="mx-1 mt-1 space-y-1">
-                @foreach($environmentVariables as $environmentVariable)
-                    <li>{{ $environmentVariable }}</li>
+        render(Blade::render(<<<'HTML'
+            <div class="mx-2 my-1 space-y-1">
+                @foreach ($pendingPrunes as $path => $environmentVariables)
+                    <div class="space-y-1">
+                        <div class="px-2 py-1 w-full max-w-90 flex justify-between bg-green-500 font-bold">
+                            <span>
+                                {{ $environmentVariables->count() }} {{ Str::plural("variable", $environmentVariables->count()) }} to remove for {{ Str::after($path, base_path()) }}
+                            </span>
+                            <span>
+                                {{ $loop->iteration }}/{{ $loop->count }}
+                            </span>
+                        </div>
+                        <div>
+                            @foreach ($environmentVariables as $environmentVariable)
+                                <div><span class="text-gray">⇁</span> {{ $environmentVariable }}</div>
+                            @endforeach
+                        </div>
+                    </div>
                 @endforeach
-            </ul>
-        </div>
-        @endforeach
-        </div>
-        ', ['pendingPrunes' => $pendingPrunes]));
+            </div>
+        HTML, ['pendingPrunes' => $pendingPrunes]));
     }
 
     private function askWhatWeShouldDoNext(bool $configFileHasBeenPublished): string

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -42,7 +42,7 @@ final class SyncCommand extends Command
         }
 
         if ($pendingUpdates->isEmpty()) {
-            render('<div class="px-1 py-1 bg-green-500 font-bold">There are no variables to sync!</div>');
+            render('<div class="mx-2 my-1 px-2 py-1 bg-green-500 font-bold">There are no variables to sync!</div>');
             return self::SUCCESS;
         }
 
@@ -82,27 +82,27 @@ final class SyncCommand extends Command
      */
     private function printPendingUpdates(Collection $pendingUpdates): void
     {
-        render(Blade::render('
-        <div>
-        @foreach($pendingUpdates as $path => $environmentCalls)
-            <div class="my-1">
-                <div class="px-2 py-1 w-full bg-green-500 font-bold">
-                    <span class="text-left w-1/2">
-                        {{ $environmentCalls->count() }} {{ Str::plural("update", $environmentCalls->count()) }} for {{ Str::after($path, base_path()) }}
-                    </span>
-                    <span class="text-right w-1/2">
-                        {{ $loop->iteration }}/{{ $loop->count }}
-                    </span>
-                </div>
-                <ul class="mx-1 mt-1 space-y-1">
-                    @foreach($environmentCalls as $environmentCall)
-                        <li>{{ $environmentCall->getKey() }}</li>
-                    @endforeach
-                </ul>
+        render(Blade::render(<<<'HTML'
+            <div class="mx-2 my-1 space-y-1">
+                @foreach ($pendingUpdates as $path => $environmentCalls)
+                    <div class="space-y-1">
+                        <div class="px-2 py-1 w-full max-w-90 flex justify-between bg-green-500 font-bold">
+                            <span>
+                                <b>{{ $environmentCalls->count() }}</b> {{ Str::plural("update", $environmentCalls->count()) }} for {{ Str::after($path, base_path()) }}
+                            </span>
+                            <span>
+                                {{ $loop->iteration }}/{{ $loop->count }}
+                            </span>
+                        </div>
+                        <div>
+                            @foreach ($environmentCalls as $environmentCall)
+                                <div><span class="text-gray">⇁</span> {{ $environmentCall->getKey() }}</div>
+                            @endforeach
+                        </div>
+                    </div>
+                @endforeach
             </div>
-        @endforeach
-        </div>
-        ', ['pendingUpdates' => $pendingUpdates]));
+        HTML, ['pendingUpdates' => $pendingUpdates]));
     }
 
     private function askWhatWeShouldDoNext(bool $configFileHasBeenPublished): string


### PR DESCRIPTION
This PR is similar to what I did for the Exchange package.

- Makes use of new additions on Termwind like `flex` and `justify-between`.
- Updates the Footer to match styling from both repos.
- Changes the bullets to "⇁", similar from what is used on Laravel Route List.

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/823088/170845891-7f4f630c-0752-4924-a3aa-5a728f6dff61.png">

<img width="870" alt="image" src="https://user-images.githubusercontent.com/823088/170845897-a861d56c-3233-4cb9-afac-4896331405f3.png">

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/823088/170845912-606bd1b4-9ac9-4838-9d3f-93e7756ba841.png">

<img width="891" alt="image" src="https://user-images.githubusercontent.com/823088/170845919-1214b7ab-8573-4b56-a2b1-320bdd747086.png">
