### PR TITLE
Allow running without aliases defined

### DIFF
--- a/src/Commands/PruneCommand.php
+++ b/src/Commands/PruneCommand.php
@@ -80,6 +80,7 @@ final class PruneCommand extends Command
     private function printPendingPrunes(Collection $pendingPrunes, BladeCompiler $blade): void
     {
         render($blade->render(<<<'HTML'
+            @php use Illuminate\Support\Str; @endphp
             <div class="mx-2 my-1 space-y-1">
                 @foreach ($pendingPrunes as $path => $environmentVariables)
                     <div class="space-y-1">

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -84,6 +84,7 @@ final class SyncCommand extends Command
     private function printPendingUpdates(Collection $pendingUpdates, BladeCompiler $blade): void
     {
         render($blade->render(<<<'HTML'
+            @php use Illuminate\Support\Str; @endphp
             <div class="mx-2 my-1 space-y-1">
                 @foreach ($pendingUpdates as $path => $environmentCalls)
                     <div class="space-y-1">


### PR DESCRIPTION
Some environments do not have aliases defined. (This could be because the developer chose to remove them from `config/app.php`, or in an environment that does not have them in the first place, such as [Laravel Zero](https://laravel-zero.com).

This PR adds explicit imports of the `Str` class in the Blade templates. This does not affect anyone using the default aliases, but allows this package to work without relying on the alias being present.