### PR TITLE
Make Env File Easier to Read by Grouping Variables Together

### DIFF
--- a/src/Envy.php
+++ b/src/Envy.php
@@ -38,10 +38,9 @@ final class Envy
     {
         // @phpstan-ignore-next-line
         return collect($this->finder->configFilePaths())
-            ->map(fn (string $path) => ($this->findEnvironmentCalls)($path, $excludeCallsWithDefaults))
-            ->flatten()
-            // @phpstan-ignore-next-line
-            ->sortBy(fn (EnvironmentCall $call) => $call->getKey());
+            ->sort()
+            ->map(fn (string $path) => ($this->findEnvironmentCalls)($path, $excludeCallsWithDefaults)->sortBy(fn (EnvironmentCall $call) => $call->getKey()))
+            ->flatten();
     }
 
     /**


### PR DESCRIPTION
Before, we used to sort all variables in alphabetical order. This made variables from the same config file appear in different places, which could be confusing. To fix this, we've changed how we sort variables.

Now, we sort variables by the config file they belong to first. Then, we sort them alphabetically within each file group. This change makes our .env file easier to read because related variables stay together.

This update makes it simpler to work with our .env file, especially when adding, changing, or looking for variables. We hope this will make things easier for everyone and reduce mistakes. If anyone has ideas on how to make things even better, please let us know!