### PR TITLE
Improved PHP 8.4 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "nikic/php-parser": "^4.19.1 || ^5.0.2",
         "nunomaduro/termwind": "^1.15 || ^2.0",
         "spatie/laravel-package-tools": "^1.16",
-        "thecodingmachine/safe": "^2.4"
+        "thecodingmachine/safe": "^2.4 || ^3.0"
     },
     "require-dev": {
         "nunomaduro/collision": "^7.0 || ^8.1",


### PR DESCRIPTION
thecodingmachine/safe released 3.0 to fix all the PHP 8.4 deprecations (which is a lot). So hope you can merge so those warnings can disappear :)

The release notes of thecodingmachine/safe 3.0 is in the link below:

https://github.com/thecodingmachine/safe/releases